### PR TITLE
add cookie domain to posthog

### DIFF
--- a/assets/js/posthog.js
+++ b/assets/js/posthog.js
@@ -22,6 +22,8 @@ if (shouldInit) {
     capture_pageview: true,
     capture_pageleave: true,
     persistence: "localStorage+cookie",
+    cross_subdomain_cookie: true,
+    cookie_domain: ".selorahomes.com",
     session_recording: {
       maskAllInputs: true,
       maskTextSelector: "*",

--- a/config.yaml
+++ b/config.yaml
@@ -150,9 +150,6 @@ privacy:
     respectDoNotTrack: true
     anonymizeIP: true
     useSessionStorage: true
-  posthog:
-    disable: false
-    respectDoNotTrack: true
   x:
     enableDNT: true
     simple: true

--- a/config.yaml
+++ b/config.yaml
@@ -150,6 +150,9 @@ privacy:
     respectDoNotTrack: true
     anonymizeIP: true
     useSessionStorage: true
+  posthog:
+    disable: false
+    respectDoNotTrack: true
   x:
     enableDNT: true
     simple: true


### PR DESCRIPTION
Avoid `Cookie “...” has been rejected for invalid domain.` errors in the console due to PostHog.