### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier-templates.yml
+++ b/.github/workflows/prettier-templates.yml
@@ -1,4 +1,6 @@
 name: Prettier Templates Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SeloraHomes/selorahomes.com/security/code-scanning/1](https://github.com/SeloraHomes/selorahomes.com/security/code-scanning/1)

To address the issue, you should explicitly specify least-privilege permissions for the workflow. In the shown snippet, these permissions need to be added either at the workflow root or for the individual job. Since there is only one job (`prettier`) and no indication that any step requires write access, the minimal necessary permission is `contents: read`. The best fix is to add a `permissions` block at the top level, after the `name` and before the `on` key, assigning `contents: read`. This change does not affect any job functionality and ensures compliance with security best practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
